### PR TITLE
[SKY-1108] Better logging for skypilot config override (#150)

### DIFF
--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -196,6 +196,7 @@ def override_skypilot_config(
         yield
         return
     original_env_config_path = _loaded_config_path
+    original_config = dict(_dict)
     config = _dict.get_nested(
         keys=tuple(),
         default_value=None,
@@ -214,6 +215,16 @@ def override_skypilot_config(
     try:
         _reload_config()
         yield
+    except ValueError as e:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError('Failed to override the SkyPilot config on API '
+                             'server with your local SkyPilot config:\n'
+                             '=== SkyPilot config on API server ===\n'
+                             f'{common_utils.dump_yaml_str(original_config)}\n'
+                             '=== Your local SkyPilot config ===\n'
+                             f'{common_utils.dump_yaml_str(override_configs)}\n'
+                             f'Details: {e}') from e
+
     finally:
         if original_env_config_path is not None:
             os.environ[ENV_VAR_SKYPILOT_CONFIG] = original_env_config_path


### PR DESCRIPTION
Better logging for skypilot config override

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
